### PR TITLE
Install plugin and generate `.gorm.pb.go` file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,28 @@ l: lint
 lint: build
 	golangci-lint run
 
-# Generate files used in tests.
+# Assumes $GOPATH/bin is in your $PATH!
 gen: generate
-generate:
+generate: install
+	# Generate the standalone module and update/lock dependencies.
 	cd proto && buf generate
 	mv gormpb/v2/gorm/v2/*.pb.go gormpb/v2
 	rm -r gormpb/v2/gorm
 	cd gormpb/v2 && go mod tidy
 
+	# Files used by tests of the plugin implementation.
 	cd cmd/protoc-gen-gorm/test && buf generate
-	rm proto/gorm/v2/options.pb.go
 
+	# Remove code generated from tests.
+	find proto -name '*.go' -delete
+
+	# Files used by tests of the internal packages.
 	cd internal/require && buf generate
+
+# Install `protoc-gen-go` into $GOPATH/bin.
+i: install
+install:
+	go install ./cmd/...
 
 # Remove all generated files.
 clean:

--- a/cmd/protoc-gen-gorm/internal_gengorm/main.go
+++ b/cmd/protoc-gen-gorm/internal_gengorm/main.go
@@ -8,5 +8,9 @@ import (
 
 // GenerateFile does nothing yet.
 func GenerateFile(flags flag.FlagSet, plugin *protogen.Plugin, file *protogen.File) (*protogen.GeneratedFile, error) {
-	return nil, nil
+	out := file.GeneratedFilenamePrefix + ".gorm.pb.go"
+	f := plugin.NewGeneratedFile(out, file.GoImportPath)
+	f.P("package ", file.GoPackageName)
+	f.P(`const A = "A"`)
+	return f, nil
 }

--- a/cmd/protoc-gen-gorm/test/buf.gen.yaml
+++ b/cmd/protoc-gen-gorm/test/buf.gen.yaml
@@ -6,3 +6,4 @@ plugins:
     opt: paths=source_relative
   - name: gorm
     out: .
+    opt: paths=source_relative

--- a/cmd/protoc-gen-gorm/test/model/model.gorm.pb.go
+++ b/cmd/protoc-gen-gorm/test/model/model.gorm.pb.go
@@ -1,0 +1,3 @@
+package model
+
+const A = "A"

--- a/cmd/protoc-gen-gorm/test/model/model_test.go
+++ b/cmd/protoc-gen-gorm/test/model/model_test.go
@@ -2,5 +2,4 @@ package model_test
 
 import (
 	_ "github.com/complex64/protoc-gen-gorm/cmd/protoc-gen-gorm/test/model"
-	_ "github.com/complex64/protoc-gen-gorm/gormpb/v2"
 )

--- a/cmd/protoc-gen-gorm/test/options/options.gorm.pb.go
+++ b/cmd/protoc-gen-gorm/test/options/options.gorm.pb.go
@@ -1,0 +1,3 @@
+package options
+
+const A = "A"

--- a/cmd/protoc-gen-gorm/test/options/options_test.go
+++ b/cmd/protoc-gen-gorm/test/options/options_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/complex64/protoc-gen-gorm/cmd/protoc-gen-gorm/test/options"
-	_ "github.com/complex64/protoc-gen-gorm/cmd/protoc-gen-gorm/test/options"
 	"github.com/complex64/protoc-gen-gorm/gormpb/v2"
 	"github.com/complex64/protoc-gen-gorm/internal/require"
 )


### PR DESCRIPTION
- `make gen` installes the plugin and invokes buf to generate the `.gorm.pb.go` files
- The files compile, but only contain a package declaration and a placeholder constant